### PR TITLE
First step towards scraping historical Senate members

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@
 source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '2.3.1'
+ruby '2.3.3'
 
 # gem "rails"
 gem 'pry'
 gem 'scraped', git: 'everypolitician/scraped'
+gem 'scraped_page_archive', git: 'everypolitician/scraped_page_archive'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.3.1'
 
 # gem "rails"
 gem 'pry'
-gem 'scraped', git: 'https://github.com/everypolitician/scraped.git'
+gem 'scraped', git: 'everypolitician/scraped'

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ ruby '2.3.3'
 
 # gem "rails"
 gem 'pry'
-gem 'scraped', git: 'everypolitician/scraped'
-gem 'scraped_page_archive', git: 'everypolitician/scraped_page_archive'
+gem 'scraped', github: 'everypolitician/scraped'
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,25 @@ GIT
       nokogiri
       require_all
 
+GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
+  specs:
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     coderay (1.1.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     field_serializer (0.3.0)
+    git (1.3.0)
+    hashdiff (0.3.1)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     nokogiri (1.6.8.1)
@@ -20,8 +34,18 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
     require_all (1.3.3)
+    safe_yaml (1.0.4)
     slop (3.6.0)
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -29,9 +53,10 @@ PLATFORMS
 DEPENDENCIES
   pry
   scraped!
+  scraped_page_archive!
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GIT
+  remote: https://github.com/everypolitician/scraped.git
+  revision: 859c5b2ff5cdeb6d166415ba2c092b422f687a7a
+  specs:
+    scraped (0.1.0)
+      field_serializer (>= 0.3.0)
+      nokogiri
+      require_all
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.1)
+    field_serializer (0.3.0)
+    method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    require_all (1.3.3)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  scraped!
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.6

--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -1,0 +1,7 @@
+require 'scraped'
+
+class MemberSection < Scraped::HTML
+  field :name do
+    row[0].text
+  end
+end

--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -2,6 +2,6 @@ require 'scraped'
 
 class MemberSection < Scraped::HTML
   field :name do
-    row[0].text
+    noko.xpath('td')[0].text
   end
 end

--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -11,9 +11,33 @@ class MemberSection < Scraped::HTML
     tds[0].text.tidy
   end
 
+  field :start_date do
+    dates[0]
+  end
+
+  field :end_date do
+    dates[1]
+  end
+
+  field :party do
+    tds[5].text.tidy
+  end
+
+  field :constituency do
+    tds[4].text.tidy
+  end
+
+  field :replacement do
+    tds[6].text.tidy
+  end
+
   private
 
   def tds
     noko.xpath('td')
+  end
+
+  def dates
+    tds[3].text.split('al').map(&:tidy).reject{ |str| str=='Sin Fecha' }
   end
 end

--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -1,8 +1,14 @@
 require 'scraped'
 
+class String
+  def tidy
+    gsub(/[[:space:]]+/, ' ').strip
+  end
+end
+
 class MemberSection < Scraped::HTML
   field :name do
-    tds[0].text
+    tds[0].text.tidy
   end
 
   private

--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -2,6 +2,12 @@ require 'scraped'
 
 class MemberSection < Scraped::HTML
   field :name do
-    noko.xpath('td')[0].text
+    tds[0].text
+  end
+
+  private
+
+  def tds
+    noko.xpath('td')
   end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,0 +1,19 @@
+require 'scraped'
+
+class MembersPage < Scraped::HTML
+  field :members do
+    trs.map do |row|
+      MemberSection.new(response: response, noko: row)
+    end
+  end
+
+  private
+
+  def table
+    noko.xpath('//table[@summary="Listado de Senadores Nacionales Historicos"]')
+  end
+
+  def trs
+    table.xpath('tbody/tr')
+  end
+end

--- a/lib/strategies/net_http_post_request.rb
+++ b/lib/strategies/net_http_post_request.rb
@@ -1,0 +1,7 @@
+require 'scraped'
+
+class NetHttpPostRequest < Scraped::Request::Strategy
+  def response
+    { body: Net::HTTP.post_form(url, config[:params]).body }
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,4 +15,5 @@ params = {
   'senado_senadoresbundle_busquedahistoricostype%5BfechaHasta%5D%5Byear%5D' => 2016
 }
 
-page = MembersPage.new(response: Net::HTTP.post_form(url, params))
+request = Scraped::Request.new(url: url, strategies: [{ strategy: NetHttpPostRequest, params: params }])
+page = MembersPage.new(response: request.response)

--- a/scraper.rb
+++ b/scraper.rb
@@ -15,4 +15,4 @@ params = {
   'senado_senadoresbundle_busquedahistoricostype%5BfechaHasta%5D%5Byear%5D' => 2016
 }
 
-res = Net::HTTP.post_form(url, params)
+page = MembersPage.new(response: Net::HTTP.post_form(url, params))

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'pry'
 require 'require_all'
+require 'scraped_page_archive/open-uri'
 
 require_rel 'lib'
 
@@ -16,4 +17,6 @@ params = {
 }
 
 request = Scraped::Request.new(url: url, strategies: [{ strategy: NetHttpPostRequest, params: params }])
-page = MembersPage.new(response: request.response)
+page = MembersPage.new(response: request.response).members.each do |member|
+  puts member.name
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,0 +1,18 @@
+require 'net/http'
+require 'pry'
+require 'require_all'
+
+require_rel 'lib'
+
+url = URI.parse('http://www.senado.gov.ar/senadores/Historico/FechaResultado')
+
+params = {
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaDesde%5D%5Bday%5D' => 1,
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaDesde%5D%5Bmonth%5D' => 1,
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaDesde%5D%5Byear%5D' => 2015,
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaHasta%5D%5Bday%5D' => 1,
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaHasta%5D%5Bmonth%5D' => 1,
+  'senado_senadoresbundle_busquedahistoricostype%5BfechaHasta%5D%5Byear%5D' => 2016
+}
+
+res = Net::HTTP.post_form(url, params)

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'pp'
 require 'pry'
 require 'require_all'
 require 'scraped_page_archive/open-uri'
@@ -18,5 +19,5 @@ params = {
 
 request = Scraped::Request.new(url: url, strategies: [{ strategy: NetHttpPostRequest, params: params }])
 page = MembersPage.new(response: request.response).members.each do |member|
-  puts member.name
+  pp member.to_h
 end


### PR DESCRIPTION
This is the first step in creating a scraper to scraper historical members of the Argentina Senate.

Sending a POST request to http://www.senado.gov.ar/senadores/Historico/FechaResultado will return a list of members within the dates specified in the request parameters.

The scraper will use Scraped but instead of using a response from Scraped::Request, we use the response returned by `Net::HTTP#post_form`.

The next step will be to loop over each page of results.